### PR TITLE
Fix how factories are created and tests of example-app

### DIFF
--- a/ExampleApp/Sources/DI/CoreComponents.swift
+++ b/ExampleApp/Sources/DI/CoreComponents.swift
@@ -6,7 +6,7 @@ let storageComponent = Component {
 }
 
 let serviceComponent = Component {
-    factory { LocalItemService(storage: $0.resolve()) as ItemService }
+    single { LocalItemService(storage: $0.resolve()) as ItemService }
 }
 
 let useCaseComponent = Component {

--- a/ExampleApp/Sources/Services/LocalItemService.swift
+++ b/ExampleApp/Sources/Services/LocalItemService.swift
@@ -2,7 +2,7 @@ import Foundation
 
 final class LocalItemService: ItemService {
 
-    private let storage: Storage
+    let storage: Storage
 
     init(storage: Storage) {
         self.storage = storage

--- a/ExampleApp/Tests/DI/AppModule.swift
+++ b/ExampleApp/Tests/DI/AppModule.swift
@@ -1,8 +1,10 @@
 @testable import App
 import Injection
 
-let appModule = Module {
-    component { storageComponent }
-    component { serviceComponent }
-    component { useCaseComponent }
+let appModule = {
+    Module {
+        component { storageComponent }
+        component { serviceComponent }
+        component { useCaseComponent }
+    }
 }

--- a/ExampleApp/Tests/Services/LocalItemServiceTests.swift
+++ b/ExampleApp/Tests/Services/LocalItemServiceTests.swift
@@ -8,7 +8,7 @@ final class LocalItemServiceTests: XCTestCase {
 
     func testSave() {
         let mockStorage = TestStorage()
-        let module = Module(parent: appModule) {
+        let module = Module(parent: appModule()) {
             factory { mockStorage as Storage }
         }
 
@@ -16,12 +16,12 @@ final class LocalItemServiceTests: XCTestCase {
 
         _ = sut.save(item: Item(id: "0", name: "name"))
 
-        expect(mockStorage.dic.count).to(equal(1))
+        expect(mockStorage.dic.count).toEventually(equal(1))
     }
 
     func testFetch() {
         let mockStorage = TestStorage()
-        let module = Module(parent: appModule) {
+        let module = Module(parent: appModule()) {
             factory { mockStorage as Storage }
         }
 

--- a/ExampleApp/Tests/UseCases/FetchItemsUseCaseTests.swift
+++ b/ExampleApp/Tests/UseCases/FetchItemsUseCaseTests.swift
@@ -8,7 +8,7 @@ final class FetchItemsUseCaseTests: XCTestCase {
 
     func testFetchReturningServiceItems() {
         let mockService = TestItemService()
-        let module = Module(parent: appModule) {
+        let module = Module(parent: appModule()) {
             factory { mockService as ItemService }
         }
         let mockItems = [Item(id: "0", name: "mock")]

--- a/ExampleApp/Tests/UseCases/ToggleItemUseCaseTests.swift
+++ b/ExampleApp/Tests/UseCases/ToggleItemUseCaseTests.swift
@@ -8,7 +8,7 @@ final class ToggleItemUseCaseTests: XCTestCase {
 
     func testToggle() {
         let mockService = TestItemService()
-        let module = Module(parent: appModule) {
+        let module = Module(parent: appModule()) {
             factory { mockService as ItemService }
         }
 

--- a/Injection/Sources/Entry.swift
+++ b/Injection/Sources/Entry.swift
@@ -2,9 +2,9 @@ import Foundation
 
 public struct Entry {
     let hash: Hash
-    let factory: AnyFactory
+    let factory: () -> AnyFactory
 
-    init<T>(type: T.Type, tag: String?, factory: AnyFactory) {
+    init<T>(type: T.Type, tag: String?, factory: @escaping @autoclosure () -> AnyFactory) {
         self.hash = Hash(type: type, tag: tag)
         self.factory = factory
     }

--- a/Injection/Sources/Module.swift
+++ b/Injection/Sources/Module.swift
@@ -53,5 +53,5 @@ extension Module {
 }
 
 private extension Array where Element == Entry {
-    var factories: [Hash: AnyFactory] { reduce(into: [Hash: AnyFactory]()) { $0[$1.hash] = $1.factory } }
+    var factories: [Hash: AnyFactory] { reduce(into: [Hash: AnyFactory]()) { $0[$1.hash] = $1.factory() } }
 }

--- a/Readme.md
+++ b/Readme.md
@@ -260,6 +260,42 @@ Remember, all factories are registred to a type/protocol, so, if you write two r
 
 Please try to have a pyramid dependency graph.
 
+### Overriding and Singleton Instances
+
+Factories are not created until they are provided to a module, so take this in mind.
+There is an important note to know when sharing singletons and parent modules.
+If you're trying to override a dependency of a singleton inside a module with a parent and the singleton it's inside the parent, this could
+not happen because that instance can be created before you override it.
+Let see an example to clarify this:
+
+```swift 
+
+let parent = Module {
+    factory { OneStorage() as Storage }
+    single { Service(storage: $0.resolve()) }
+}
+
+let child = Module(parent: parent) {
+    factory { OtherStorage() as Storage }
+}
+
+let service = parent.resolve() as Service
+let childService = child.resolve() as Service
+
+```
+
+The storage of childService will be the same as Service because it's a singleton already resolved on the parent.
+But if you change the call order then the singleton will be with the `OtherService` storage.
+This is a little bit hard to see but it's the normal behaviour.
+
+Take special care about this when testing because if you share a module between all the tests, this can raise.
+
+For this, like you will see on the application test, the module to share its a function that returns the module, so always I get a fresh copy 
+of the module and I can override without problems.
+
+**So, keep in mind, TRY TO AVOID OVERRIDE SINGLETON DEPENDENCIES, BECAUSE THE SINGLETON CAN BE ALREADY CREATED WHEN YOU THINK YOU'RE CREATING IT**
+
+
 ## Installation
 
 This is a pre alpha version, so maybe it will change, hope not to much, but the option it's here.


### PR DESCRIPTION
Discovered special behaviour when overriding dependencies on singleton factories.
Changed how `Entry` entity works. Instead of create the Factory on his init, the factory won't be created until you attach it to a module.
With this you can share factories with components and if they are on different modules they will be different factories. 
This is truly important when working with singletons.

Added this to the `Readme`

Factories are not created until they are provided to a module, so take this in mind.
There is an important note to know when sharing singletons and parent modules.
If you're trying to override a dependency of a singleton inside a module with a parent and the singleton it's inside the parent, this could
not happen because that instance can be created before you override it.
Let see an example to clarify this:

```swift 

let parent = Module {
    factory { OneStorage() as Storage }
    single { Service(storage: $0.resolve()) }
}

let child = Module(parent: parent) {
    factory { OtherStorage() as Storage }
}

let service = parent.resolve() as Service
let childService = child.resolve() as Service

```

The storage of childService will be the same as Service because it's a singleton already resolved on the parent.
But if you change the call order then the singleton will be with the `OtherService` storage.
This is a little bit hard to see but it's the normal behaviour.

Take special care about this when testing because if you share a module between all the tests, this can raise.

For this, like you will see on the application test, the module to share its a function that returns the module, so always I get a fresh copy 
of the module and I can override without problems.

**So, keep in mind, TRY TO AVOID OVERRIDE SINGLETON DEPENDENCIES, BECAUSE THE SINGLETON CAN BE ALREADY CREATED WHEN YOU THINK YOUR CREATING IT**