### PR TITLE
@Inject Property Wrapper support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.2] - 
 ### Added
+- @Inject support
 - New Logger to print whats happening while resolving dependencies.
 - Added a changelog 💣
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.2] - 
 ### Added
-- @Inject support
+- @Inject Property Wrapper Support
 - New Logger to print whats happening while resolving dependencies.
 - Added a changelog 💣
 

--- a/Injection/Injection.xcodeproj/project.pbxproj
+++ b/Injection/Injection.xcodeproj/project.pbxproj
@@ -290,8 +290,6 @@
 		1CAAA154DA601239AB67CF0B /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = E3A0472F66E7B5BE1659052D /* Build configuration list for PBXProject "Injection" */;
 			compatibilityVersion = "Xcode 9.3";
@@ -360,7 +358,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${PROJECT_DIR}/../scripts/swiftformat.sh ";
+			shellScript = "${PROJECT_DIR}/../scripts/swiftformat.sh \n";
 		};
 		6CAC9E5A4C3B91EC70632042 /* Embed Precompiled Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Injection/Injection.xcodeproj/project.pbxproj
+++ b/Injection/Injection.xcodeproj/project.pbxproj
@@ -15,7 +15,12 @@
 		3D51CEA1F429C6CC2942B80C /* ModuleBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F29E127FA46B38905B03A959 /* ModuleBuilderTests.swift */; };
 		48917DADAAC03C895A632077 /* Registrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C645CEA45199BBCAE8E8EB /* Registrations.swift */; };
 		678FC8AFB8F69F7C61D3FAA2 /* Module.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0045B4C4B443C01EB653AF59 /* Module.swift */; };
+<<<<<<< HEAD
 		93E103D383C3CBDED1495792 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C9D4AE9D712C0118A53CCA /* Logger.swift */; };
+=======
+		8D86BD53242BD83100D4DAA8 /* Inject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D86BD52242BD83100D4DAA8 /* Inject.swift */; };
+		8D86BD55242BDACA00D4DAA8 /* InjectPropertyWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D86BD54242BDACA00D4DAA8 /* InjectPropertyWrapperTests.swift */; };
+>>>>>>> inject - Inject property wrapper created and tested
 		9F36566AEE6C609C36572589 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C0586E0BA11FB007C48903C /* Component.swift */; };
 		A3EB30291C9918E9599151DD /* FactoriesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3C12DF0B54E3EA83DE87CA /* FactoriesTests.swift */; };
 		B424FC738CBE6BAAEED4D53B /* Factories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42E8BE59B01D576899EA2D03 /* Factories.swift */; };
@@ -80,6 +85,8 @@
 		76C83B5A607A7CC41FEB54BC /* ComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentTests.swift; sourceTree = "<group>"; };
 		8104A7E9144B5931B872EA71 /* ResolverParentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolverParentTests.swift; sourceTree = "<group>"; };
 		8A3C12DF0B54E3EA83DE87CA /* FactoriesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactoriesTests.swift; sourceTree = "<group>"; };
+		8D86BD52242BD83100D4DAA8 /* Inject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Inject.swift; sourceTree = "<group>"; };
+		8D86BD54242BDACA00D4DAA8 /* InjectPropertyWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectPropertyWrapperTests.swift; sourceTree = "<group>"; };
 		A14179FAA42BCFF82A2FFF98 /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
 		ABB205C06640348F009EB315 /* Hash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hash.swift; sourceTree = "<group>"; };
 		BE4FDE61301AA44F4B46C5BF /* Injection.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Injection.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -129,6 +136,7 @@
 				0045B4C4B443C01EB653AF59 /* Module.swift */,
 				51E1798557EE00BFE321EE24 /* ModuleBuilder.swift */,
 				63C645CEA45199BBCAE8E8EB /* Registrations.swift */,
+				8D86BD52242BD83100D4DAA8 /* Inject.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -165,6 +173,7 @@
 				51C5A9A24BD9390C0142DA3A /* ModuleTests.swift */,
 				8104A7E9144B5931B872EA71 /* ResolverParentTests.swift */,
 				6CA9C4E2F726DD90F9B857BC /* ResolveTests.swift */,
+				8D86BD54242BDACA00D4DAA8 /* InjectPropertyWrapperTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -284,8 +293,6 @@
 		1CAAA154DA601239AB67CF0B /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = E3A0472F66E7B5BE1659052D /* Build configuration list for PBXProject "Injection" */;
 			compatibilityVersion = "Xcode 9.3";
@@ -400,6 +407,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1F6CB6A7AD2FBEC34FB7BE28 /* ComponentTests.swift in Sources */,
+				8D86BD55242BDACA00D4DAA8 /* InjectPropertyWrapperTests.swift in Sources */,
 				A3EB30291C9918E9599151DD /* FactoriesTests.swift in Sources */,
 				D1293026BA5D8865178327B6 /* HashTests.swift in Sources */,
 				E94E9812FA432AE45AEE5461 /* InjectTests.swift in Sources */,
@@ -416,6 +424,7 @@
 			files = (
 				9F36566AEE6C609C36572589 /* Component.swift in Sources */,
 				EB91554C15A78FDEE7CEE72E /* Entry.swift in Sources */,
+				8D86BD53242BD83100D4DAA8 /* Inject.swift in Sources */,
 				B424FC738CBE6BAAEED4D53B /* Factories.swift in Sources */,
 				3293A63C5BFF5635329AB678 /* Hash.swift in Sources */,
 				F88E34808EB209752657ED2E /* Injection.swift in Sources */,

--- a/Injection/Injection.xcodeproj/project.pbxproj
+++ b/Injection/Injection.xcodeproj/project.pbxproj
@@ -15,12 +15,7 @@
 		3D51CEA1F429C6CC2942B80C /* ModuleBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F29E127FA46B38905B03A959 /* ModuleBuilderTests.swift */; };
 		48917DADAAC03C895A632077 /* Registrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C645CEA45199BBCAE8E8EB /* Registrations.swift */; };
 		678FC8AFB8F69F7C61D3FAA2 /* Module.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0045B4C4B443C01EB653AF59 /* Module.swift */; };
-<<<<<<< HEAD
 		93E103D383C3CBDED1495792 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C9D4AE9D712C0118A53CCA /* Logger.swift */; };
-=======
-		8D86BD53242BD83100D4DAA8 /* Inject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D86BD52242BD83100D4DAA8 /* Inject.swift */; };
-		8D86BD55242BDACA00D4DAA8 /* InjectPropertyWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D86BD54242BDACA00D4DAA8 /* InjectPropertyWrapperTests.swift */; };
->>>>>>> inject - Inject property wrapper created and tested
 		9F36566AEE6C609C36572589 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C0586E0BA11FB007C48903C /* Component.swift */; };
 		A3EB30291C9918E9599151DD /* FactoriesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3C12DF0B54E3EA83DE87CA /* FactoriesTests.swift */; };
 		B424FC738CBE6BAAEED4D53B /* Factories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42E8BE59B01D576899EA2D03 /* Factories.swift */; };
@@ -28,8 +23,10 @@
 		C7F28B37BA67C2282138537C /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC3241E785FBBACEC6E76EDE /* Nimble.framework */; };
 		D1293026BA5D8865178327B6 /* HashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E0AFBA6FB78CC4C176A097 /* HashTests.swift */; };
 		D2DE76710FAB9D4FC83BDD00 /* Injection.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = BE4FDE61301AA44F4B46C5BF /* Injection.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D9E2E83FD684642D14F2688B /* InjectPropertyWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02906EB5C8BC9A60983F5226 /* InjectPropertyWrapperTests.swift */; };
 		E94E9812FA432AE45AEE5461 /* InjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 745DA0525EE5E16FAE9378CC /* InjectTests.swift */; };
 		E9C18C8B6CEBC773FCD6E420 /* ResolveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CA9C4E2F726DD90F9B857BC /* ResolveTests.swift */; };
+		E9F101B69B05F6BBBAEAE5F2 /* Inject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C39796D4CDA3C8E53F89729 /* Inject.swift */; };
 		EB91554C15A78FDEE7CEE72E /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14179FAA42BCFF82A2FFF98 /* Entry.swift */; };
 		F88E34808EB209752657ED2E /* Injection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18A1732DCD8D6EA7C8C68AE0 /* Injection.swift */; };
 		FEC4D83F4E69CDA953236C92 /* LogLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5BEE81B4CC9D222D963EA7 /* LogLevel.swift */; };
@@ -70,10 +67,12 @@
 /* Begin PBXFileReference section */
 		0045B4C4B443C01EB653AF59 /* Module.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Module.swift; sourceTree = "<group>"; };
 		0258C71B7A498C50A7906BC9 /* Tests.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Tests.plist; sourceTree = "<group>"; };
+		02906EB5C8BC9A60983F5226 /* InjectPropertyWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectPropertyWrapperTests.swift; sourceTree = "<group>"; };
 		18A1732DCD8D6EA7C8C68AE0 /* Injection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Injection.swift; sourceTree = "<group>"; };
 		40D7E8D58D407945EC576AC8 /* Injection.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Injection.plist; sourceTree = "<group>"; };
 		42E8BE59B01D576899EA2D03 /* Factories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Factories.swift; sourceTree = "<group>"; };
 		47E0AFBA6FB78CC4C176A097 /* HashTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashTests.swift; sourceTree = "<group>"; };
+		4C39796D4CDA3C8E53F89729 /* Inject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Inject.swift; sourceTree = "<group>"; };
 		51C5A9A24BD9390C0142DA3A /* ModuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleTests.swift; sourceTree = "<group>"; };
 		51E1798557EE00BFE321EE24 /* ModuleBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleBuilder.swift; sourceTree = "<group>"; };
 		5C0586E0BA11FB007C48903C /* Component.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Component.swift; sourceTree = "<group>"; };
@@ -85,8 +84,6 @@
 		76C83B5A607A7CC41FEB54BC /* ComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentTests.swift; sourceTree = "<group>"; };
 		8104A7E9144B5931B872EA71 /* ResolverParentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolverParentTests.swift; sourceTree = "<group>"; };
 		8A3C12DF0B54E3EA83DE87CA /* FactoriesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactoriesTests.swift; sourceTree = "<group>"; };
-		8D86BD52242BD83100D4DAA8 /* Inject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Inject.swift; sourceTree = "<group>"; };
-		8D86BD54242BDACA00D4DAA8 /* InjectPropertyWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectPropertyWrapperTests.swift; sourceTree = "<group>"; };
 		A14179FAA42BCFF82A2FFF98 /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
 		ABB205C06640348F009EB315 /* Hash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hash.swift; sourceTree = "<group>"; };
 		BE4FDE61301AA44F4B46C5BF /* Injection.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Injection.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -132,11 +129,11 @@
 				A14179FAA42BCFF82A2FFF98 /* Entry.swift */,
 				42E8BE59B01D576899EA2D03 /* Factories.swift */,
 				ABB205C06640348F009EB315 /* Hash.swift */,
+				4C39796D4CDA3C8E53F89729 /* Inject.swift */,
 				18A1732DCD8D6EA7C8C68AE0 /* Injection.swift */,
 				0045B4C4B443C01EB653AF59 /* Module.swift */,
 				51E1798557EE00BFE321EE24 /* ModuleBuilder.swift */,
 				63C645CEA45199BBCAE8E8EB /* Registrations.swift */,
-				8D86BD52242BD83100D4DAA8 /* Inject.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -168,12 +165,12 @@
 				76C83B5A607A7CC41FEB54BC /* ComponentTests.swift */,
 				8A3C12DF0B54E3EA83DE87CA /* FactoriesTests.swift */,
 				47E0AFBA6FB78CC4C176A097 /* HashTests.swift */,
+				02906EB5C8BC9A60983F5226 /* InjectPropertyWrapperTests.swift */,
 				745DA0525EE5E16FAE9378CC /* InjectTests.swift */,
 				F29E127FA46B38905B03A959 /* ModuleBuilderTests.swift */,
 				51C5A9A24BD9390C0142DA3A /* ModuleTests.swift */,
 				8104A7E9144B5931B872EA71 /* ResolverParentTests.swift */,
 				6CA9C4E2F726DD90F9B857BC /* ResolveTests.swift */,
-				8D86BD54242BDACA00D4DAA8 /* InjectPropertyWrapperTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -293,6 +290,8 @@
 		1CAAA154DA601239AB67CF0B /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				TargetAttributes = {
+				};
 			};
 			buildConfigurationList = E3A0472F66E7B5BE1659052D /* Build configuration list for PBXProject "Injection" */;
 			compatibilityVersion = "Xcode 9.3";
@@ -407,9 +406,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				1F6CB6A7AD2FBEC34FB7BE28 /* ComponentTests.swift in Sources */,
-				8D86BD55242BDACA00D4DAA8 /* InjectPropertyWrapperTests.swift in Sources */,
 				A3EB30291C9918E9599151DD /* FactoriesTests.swift in Sources */,
 				D1293026BA5D8865178327B6 /* HashTests.swift in Sources */,
+				D9E2E83FD684642D14F2688B /* InjectPropertyWrapperTests.swift in Sources */,
 				E94E9812FA432AE45AEE5461 /* InjectTests.swift in Sources */,
 				3D51CEA1F429C6CC2942B80C /* ModuleBuilderTests.swift in Sources */,
 				BE8B6E0A603C527B2FD6709B /* ModuleTests.swift in Sources */,
@@ -424,9 +423,9 @@
 			files = (
 				9F36566AEE6C609C36572589 /* Component.swift in Sources */,
 				EB91554C15A78FDEE7CEE72E /* Entry.swift in Sources */,
-				8D86BD53242BD83100D4DAA8 /* Inject.swift in Sources */,
 				B424FC738CBE6BAAEED4D53B /* Factories.swift in Sources */,
 				3293A63C5BFF5635329AB678 /* Hash.swift in Sources */,
+				E9F101B69B05F6BBBAEAE5F2 /* Inject.swift in Sources */,
 				F88E34808EB209752657ED2E /* Injection.swift in Sources */,
 				FEC4D83F4E69CDA953236C92 /* LogLevel.swift in Sources */,
 				93E103D383C3CBDED1495792 /* Logger.swift in Sources */,

--- a/Injection/Sources/Inject.swift
+++ b/Injection/Sources/Inject.swift
@@ -26,6 +26,7 @@ public final class Inject<T>: InjectedProperty {
     }
 }
 
+@discardableResult
 func fill<T>(_ object: T, by module: Module) -> T {
     let mirror = Mirror(reflecting: object)
 

--- a/Injection/Sources/Inject.swift
+++ b/Injection/Sources/Inject.swift
@@ -1,28 +1,30 @@
 import Foundation
 
 protocol InjectedProperty {
-    static var injectType: Any.Type { get }
-
     func inject(by module: Module)
 }
 
 @propertyWrapper
 public final class Inject<T>: InjectedProperty {
-    static var injectType: Any.Type {
-        return T.self
-    }
-
-    var _value: T?
 
     public private(set) var wrappedValue: T {
         get { _value! }
         set { _value = newValue }
     }
 
-    public init() {}
+    var _value: T?
+    private let tag: String?
+
+    public init() {
+        self.tag = nil
+    }
+
+    public init(tag: String?) {
+        self.tag = tag
+    }
 
     func inject(by module: Module) {
-        wrappedValue = module.resolve()
+        wrappedValue = module.resolve(tag: tag)
     }
 }
 

--- a/Injection/Sources/Inject.swift
+++ b/Injection/Sources/Inject.swift
@@ -22,7 +22,7 @@ public final class Inject<T>: InjectedProperty {
     public init() {}
 
     func inject(by module: Module) {
-        _value = module.resolve()
+        wrappedValue = module.resolve()
     }
 }
 

--- a/Injection/Sources/Inject.swift
+++ b/Injection/Sources/Inject.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+protocol InjectedProperty {
+    static var injectType: Any.Type { get }
+
+    func inject(by module: Module)
+}
+
+@propertyWrapper
+public final class Inject<T>: InjectedProperty {
+    static var injectType: Any.Type {
+        return T.self
+    }
+
+    var _value: T?
+
+    public private(set) var wrappedValue: T {
+        get { _value! }
+        set { _value = newValue }
+    }
+
+    public init() {}
+
+    func inject(by module: Module) {
+        _value = module.resolve()
+    }
+}
+
+func fill<T>(_ object: T, by module: Module) -> T {
+    let mirror = Mirror(reflecting: object)
+
+    var superClassMirror = mirror.superclassMirror
+    while superClassMirror != nil {
+        superClassMirror?.children.forEach { fill($0, module) }
+        superClassMirror = superClassMirror?.superclassMirror
+    }
+    mirror.children.forEach { fill($0, module) }
+    return object
+}
+
+private func fill(_ child: Mirror.Child, _ module: Module) {
+    guard let injectable = child.value as? InjectedProperty else { return }
+    return injectable.inject(by: module)
+}

--- a/Injection/Sources/Module.swift
+++ b/Injection/Sources/Module.swift
@@ -15,8 +15,10 @@ public final class Module {
 
     public func resolve<T>(tag: String? = nil) -> T {
         Logger.log(message: "Solving type\(tag.log): \(T.self)")
-        return factories[Hash(type: T.self, tag: tag)]?.build(self) as? T
-            ?? parent!.resolve(tag: tag, child: self)
+        return fill(
+            factories[Hash(type: T.self, tag: tag)]?.build(self) as? T
+            ?? parent!.resolve(tag: tag, child: self),
+             by: self)
     }
     
     private func resolve<T>(tag: String?, child: Module) -> T {

--- a/Injection/Sources/Module.swift
+++ b/Injection/Sources/Module.swift
@@ -17,10 +17,11 @@ public final class Module {
         Logger.log(message: "Solving type\(tag.log): \(T.self)")
         return fill(
             factories[Hash(type: T.self, tag: tag)]?.build(self) as? T
-            ?? parent!.resolve(tag: tag, child: self),
-             by: self)
+                ?? parent!.resolve(tag: tag, child: self),
+            by: self
+        )
     }
-    
+
     private func resolve<T>(tag: String?, child: Module) -> T {
         Logger.log(message: "Parent solving type\(tag.log): \(T.self)")
         return factories[Hash(type: T.self, tag: tag)]?.build(child) as? T

--- a/Injection/Sources/ModuleBuilder.swift
+++ b/Injection/Sources/ModuleBuilder.swift
@@ -3,7 +3,9 @@ import Foundation
 open class ModuleBuilder<T> {
     public lazy var module: Module = { Injection.module.expand(with: component()) }()
 
-    public init() {}
+    public init() {
+        fill(self, by: module)
+    }
 
     open func component() -> Component? { nil }
 

--- a/Injection/Tests/InjectPropertyWrapperTests.swift
+++ b/Injection/Tests/InjectPropertyWrapperTests.swift
@@ -38,6 +38,19 @@ final class InjectPropertyWrapperTests: XCTestCase {
         expect(cb.a.b.name).to(equal("Inject"))
     }
 
+    func testInjectOnModuleBuilder() {
+        let module = Module {
+            factory { B(name: "Inject") }
+            factory { Built(b: $0.resolve()) }
+        }
+        Injection.initialize(with: module)
+        
+        let b = TestModuleBuilder().build()
+
+        expect(b.name).to(equal("Inject"))
+        Injection.reset()
+    }
+
 }
 
 private struct A {
@@ -54,4 +67,18 @@ private class CA {
 
 private class CB: CA {
     @Inject var a: A
+}
+
+private struct Built {
+    let b: B
+}
+
+private final class TestModuleBuilder: ModuleBuilder<B> {
+
+    @Inject var built: Built
+
+    override func build() -> B {
+        built.b
+    }
+
 }

--- a/Injection/Tests/InjectPropertyWrapperTests.swift
+++ b/Injection/Tests/InjectPropertyWrapperTests.swift
@@ -26,6 +26,18 @@ final class InjectPropertyWrapperTests: XCTestCase {
         expect(ca.b.name).to(equal("Inject"))
     }
 
+    func testInjectedWithInheritance() {
+        let module = Module {
+            factory { A() }
+            factory { CB() }
+            factory { B(name: "Inject") }
+        }
+        let cb: CB = module.resolve()
+
+        expect(cb.b.name).to(equal("Inject"))
+        expect(cb.a.b.name).to(equal("Inject"))
+    }
+
 }
 
 private struct A {
@@ -38,4 +50,8 @@ private struct B {
 
 private class CA {
     @Inject var b: B
+}
+
+private class CB: CA {
+    @Inject var a: A
 }

--- a/Injection/Tests/InjectPropertyWrapperTests.swift
+++ b/Injection/Tests/InjectPropertyWrapperTests.swift
@@ -44,7 +44,7 @@ final class InjectPropertyWrapperTests: XCTestCase {
             factory { Built(b: $0.resolve()) }
         }
         Injection.initialize(with: module)
-        
+
         let b = TestModuleBuilder().build()
 
         expect(b.name).to(equal("Inject"))

--- a/Injection/Tests/InjectPropertyWrapperTests.swift
+++ b/Injection/Tests/InjectPropertyWrapperTests.swift
@@ -1,0 +1,41 @@
+import Foundation
+@testable import Injection
+import Nimble
+import XCTest
+
+final class InjectPropertyWrapperTests: XCTestCase {
+
+    func testInjectedStruct() {
+        let module = Module {
+            factory { A() }
+            factory { B(name: "Inject") }
+        }
+
+        let a: A = module.resolve()
+
+        expect(a.b.name).to(equal("Inject"))
+    }
+
+    func testInjectedStructOnClass() {
+        let module = Module {
+            factory { CA() }
+            factory { B(name: "Inject") }
+        }
+        let ca: CA = module.resolve()
+
+        expect(ca.b.name).to(equal("Inject"))
+    }
+
+}
+
+private struct A {
+    @Inject var b: B
+}
+
+private struct B {
+    let name: String
+}
+
+private class CA {
+    @Inject var b: B
+}

--- a/Injection/Tests/InjectPropertyWrapperTests.swift
+++ b/Injection/Tests/InjectPropertyWrapperTests.swift
@@ -51,6 +51,18 @@ final class InjectPropertyWrapperTests: XCTestCase {
         Injection.reset()
     }
 
+    func testInjectWithTag() {
+        let module = Module {
+            factory { ATag() }
+            factory { B(name: "Inject") }
+            factory(tag: "tag") { B(name: "tagged") }
+        }
+
+        let a = module.resolve() as ATag
+
+        expect(a.b.name).to(equal("tagged"))
+    }
+
 }
 
 private struct A {
@@ -71,6 +83,10 @@ private class CB: CA {
 
 private struct Built {
     let b: B
+}
+
+private struct ATag {
+    @Inject(tag: "tag") var b: B
 }
 
 private final class TestModuleBuilder: ModuleBuilder<B> {

--- a/Readme.md
+++ b/Readme.md
@@ -344,6 +344,8 @@ final class MagicModuleBuilder: ModuleBuilder<UIViewController> {
 So if you want to have resolved properties inside those instances with the module provided, use dependency injection by constructor or set them 
 manually afther the creation.
 
+You can reference tagged dependencies with `@Inject` using `@Inject(tag: "yourtag")`
+
 ### Logger
 
 There is a Logger that will print all the operations while reoslving a type.

--- a/Readme.md
+++ b/Readme.md
@@ -297,6 +297,49 @@ of the module and I can override without problems.
 
 **So, keep in mind, TRY TO AVOID OVERRIDE SINGLETON DEPENDENCIES, BECAUSE THE SINGLETON CAN BE ALREADY CREATED WHEN YOU THINK YOU'RE CREATING IT**
 
+### @Inject
+
+You can use `@Inject` property wrapper to auto fill variables with resolved instances on your code.
+This will fill those variables with the factories provided by the module where you're resolving the instances.
+
+```swift 
+
+class Bar {}
+
+class Foo {
+    @Inject var bar: Bar
+}
+
+let module = Module {
+    factory { Foo() }
+    factory { Bar() }
+}
+
+// This will have the bar dependency filled.
+let foo = module.resolve() as Foo
+
+```
+
+And you can use this feature also on your ModuleBuilders if you want. These instances will be resolved with the module extendended in your ModuleBuilder.
+
+```swift
+final class MagicModuleBuilder: ModuleBuilder<UIViewController> {
+
+    @Inject var some: Some
+
+    func component() -> Component? {
+        Component {
+            factory { Some() }
+        }
+    } 
+
+    override func build() -> UIViewController {
+        MagicViewController(some: some)
+    }
+
+}
+```
+
 
 ### Logger
 

--- a/Readme.md
+++ b/Readme.md
@@ -340,6 +340,9 @@ final class MagicModuleBuilder: ModuleBuilder<UIViewController> {
 }
 ```
 
+**Note** Your custom builded classes inside `build()` method on Module builder won't be filled since them are not resolved by the module. 
+So if you want to have resolved properties inside those instances with the module provided, use dependency injection by constructor or set them 
+manually afther the creation.
 
 ### Logger
 


### PR DESCRIPTION
Closes #9 

### @Inject

You can use `@Inject` property wrapper to auto fill variables with resolved instances on your code.
This will fill those variables with the factories provided by the module where you're resolving the instances.

```swift 

class Bar {}

class Foo {
    @Inject var bar: Bar
}

let module = Module {
    factory { Foo() }
    factory { Bar() }
}

// This will have the bar dependency filled.
let foo = module.resolve() as Foo

```

And you can use this feature also on your ModuleBuilders if you want. These instances will be resolved with the module extendended in your ModuleBuilder.

```swift
final class MagicModuleBuilder: ModuleBuilder<UIViewController> {

    @Inject var some: Some

    func component() -> Component? {
        Component {
            factory { Some() }
        }
    } 

    override func build() -> UIViewController {
        MagicViewController(some: some)
    }

}
```

**Note** Your custom builded classes inside `build()` method on Module builder won't be filled since them are not resolved by the module. 
So if you want to have resolved properties inside those instances with the module provided, use dependency injection by constructor or set them 
manually afther the creation.