### PR TITLE
11 resolve shared module

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.2] - 
 ### Added
+- New `resolve()` shared function to resolve dependencies with the shared module instances.
 - New Logger to print whats happening while resolving dependencies.
 - Added a changelog 💣
 

--- a/Injection/Injection.xcodeproj/project.pbxproj
+++ b/Injection/Injection.xcodeproj/project.pbxproj
@@ -284,8 +284,6 @@
 		1CAAA154DA601239AB67CF0B /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = E3A0472F66E7B5BE1659052D /* Build configuration list for PBXProject "Injection" */;
 			compatibilityVersion = "Xcode 9.3";
@@ -354,7 +352,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${PROJECT_DIR}/../scripts/swiftformat.sh ";
+			shellScript = "${PROJECT_DIR}/../scripts/swiftformat.sh \n";
 		};
 		6CAC9E5A4C3B91EC70632042 /* Embed Precompiled Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Injection/Sources/Injection.swift
+++ b/Injection/Sources/Injection.swift
@@ -16,6 +16,10 @@ public func injectMe(_ module: Module) {
     Injection.initialize(with: module)
 }
 
+public func resolve<T>(tag: String? = nil) -> T {
+    Injection.module.resolve(tag: tag)
+}
+
 final class Injection {
     private static let shared: Injection = .init()
     static var module: Module { shared.module }

--- a/Injection/Sources/Module.swift
+++ b/Injection/Sources/Module.swift
@@ -18,7 +18,7 @@ public final class Module {
         return factories[Hash(type: T.self, tag: tag)]?.build(self) as? T
             ?? parent!.resolve(tag: tag, child: self)
     }
-    
+
     private func resolve<T>(tag: String?, child: Module) -> T {
         Logger.log(message: "Parent solving type\(tag.log): \(T.self)")
         return factories[Hash(type: T.self, tag: tag)]?.build(child) as? T

--- a/Injection/Tests/ResolveTests.swift
+++ b/Injection/Tests/ResolveTests.swift
@@ -43,6 +43,17 @@ final class ResolveTests: XCTestCase {
         expect { _ = module.resolve() as C }.toNot(throwAssertion())
     }
 
+    func testSharedResolveFunction() {
+        let module = Module {
+            factory { A() }
+        }
+        injectMe(module)
+
+        expect { _ = resolve() as A }.toNot(throwAssertion())
+
+        Injection.reset()
+    }
+
 }
 
 private struct A {}

--- a/Readme.md
+++ b/Readme.md
@@ -220,14 +220,14 @@ This provide to us the ability of override real components with parent dependenc
 
 ### More tips.
 
-How can I create a singleton?:
+- How can I create a singleton?:
 ```swift
 let component = Component {
     single { YourSingleton() }
 }
 ```
 
-The module only can be created with components?:
+- The module only can be created with components?:
 No, you can create a module with factories, singletons and components, eg:
 ```swift 
 let module = Module {
@@ -237,7 +237,7 @@ let module = Module {
 }
 ```
 
-Do you need two factories with the same type/protocol?
+- Do you need two factories with the same type/protocol?
 Use tags:
 ```swift
 let module = Module {
@@ -249,7 +249,7 @@ let module = Module {
 module.resolve(tag: "hisMagicService")
 ```
 
-Do you need create a new Module within other Module?
+- Do you need create a new Module within other Module?
 Yes, you can. You can create a new Module with a parent module simply doing:
 
 ```swift
@@ -261,6 +261,16 @@ let module = Module(parent: yourParentModule) {
 Remember, all factories are registred to a type/protocol, so, if you write two registrations for the same type, the last will override the first, so take this in mind. 
 
 Please try to have a pyramid dependency graph.
+
+- Do you need to resolve some dependency provided by `injectMe` out from a ModuleBuilder?
+You can do it using:
+
+```swift 
+let thing: Magic = resolve()
+```
+
+**Remember** This will only use the instances provided on `injectMe`
+
 
 ### Overriding and Singleton Instances
 


### PR DESCRIPTION
Closes #11 

Provided `resolve()` function to resolve dependencies provided on `injectMe` out of ModuleBuilders.

- Updated Readme
- Updated changelog