### PR TITLE
9 inject support new

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,10 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `@Inject` & `@LazyInject` by [@JulianAlonso](https://github.com/julianalonso)
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
 ## [0.0.3] -
 
 ### Added
-- Added SPM support
+- Added SPM support by [@JulianAlonso](https://github.com/julianalonso)
 
 ### Changed
 
@@ -24,10 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.2] - 
 ### Added
-- Added callAsFunction to Module to use it like `factory { Some(dependency: $0() ) }`
-- New `resolve()` shared function to resolve dependencies with the shared module instances.
-- New Logger to print whats happening while resolving dependencies.
-- Added a changelog 💣
+- Added callAsFunction to Module to use it like `factory { Some(dependency: $0() ) }` by [@JulianAlonso](https://github.com/julianalonso)
+- New `resolve()` shared function to resolve dependencies with the shared module instances. by [@JulianAlonso](https://github.com/julianalonso)
+- New Logger to print whats happening while resolving dependencies. by [@JulianAlonso](https://github.com/julianalonso)
+- Added a changelog 💣 by [@JulianAlonso](https://github.com/julianalonso)
 
 ### Changed
 

--- a/Injection/Injection.xcodeproj/project.pbxproj
+++ b/Injection/Injection.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		3D51CEA1F429C6CC2942B80C /* ModuleBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F29E127FA46B38905B03A959 /* ModuleBuilderTests.swift */; };
 		48917DADAAC03C895A632077 /* Registrations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63C645CEA45199BBCAE8E8EB /* Registrations.swift */; };
 		678FC8AFB8F69F7C61D3FAA2 /* Module.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0045B4C4B443C01EB653AF59 /* Module.swift */; };
+		8DDE60FD2457327700654EF3 /* Inject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DDE60FC2457327700654EF3 /* Inject.swift */; };
+		8DDE60FF2457391E00654EF3 /* InjectAnnotationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DDE60FE2457391E00654EF3 /* InjectAnnotationTests.swift */; };
 		93E103D383C3CBDED1495792 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69C9D4AE9D712C0118A53CCA /* Logger.swift */; };
 		9F36566AEE6C609C36572589 /* Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C0586E0BA11FB007C48903C /* Component.swift */; };
 		A3EB30291C9918E9599151DD /* FactoriesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A3C12DF0B54E3EA83DE87CA /* FactoriesTests.swift */; };
@@ -80,6 +82,8 @@
 		76C83B5A607A7CC41FEB54BC /* ComponentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentTests.swift; sourceTree = "<group>"; };
 		8104A7E9144B5931B872EA71 /* ResolverParentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResolverParentTests.swift; sourceTree = "<group>"; };
 		8A3C12DF0B54E3EA83DE87CA /* FactoriesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FactoriesTests.swift; sourceTree = "<group>"; };
+		8DDE60FC2457327700654EF3 /* Inject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Inject.swift; sourceTree = "<group>"; };
+		8DDE60FE2457391E00654EF3 /* InjectAnnotationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InjectAnnotationTests.swift; sourceTree = "<group>"; };
 		A14179FAA42BCFF82A2FFF98 /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
 		ABB205C06640348F009EB315 /* Hash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hash.swift; sourceTree = "<group>"; };
 		BE4FDE61301AA44F4B46C5BF /* Injection.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Injection.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -129,6 +133,7 @@
 				0045B4C4B443C01EB653AF59 /* Module.swift */,
 				51E1798557EE00BFE321EE24 /* ModuleBuilder.swift */,
 				63C645CEA45199BBCAE8E8EB /* Registrations.swift */,
+				8DDE60FC2457327700654EF3 /* Inject.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -165,6 +170,7 @@
 				51C5A9A24BD9390C0142DA3A /* ModuleTests.swift */,
 				8104A7E9144B5931B872EA71 /* ResolverParentTests.swift */,
 				6CA9C4E2F726DD90F9B857BC /* ResolveTests.swift */,
+				8DDE60FE2457391E00654EF3 /* InjectAnnotationTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -284,8 +290,6 @@
 		1CAAA154DA601239AB67CF0B /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = E3A0472F66E7B5BE1659052D /* Build configuration list for PBXProject "Injection" */;
 			compatibilityVersion = "Xcode 9.3";
@@ -405,6 +409,7 @@
 				BE8B6E0A603C527B2FD6709B /* ModuleTests.swift in Sources */,
 				E9C18C8B6CEBC773FCD6E420 /* ResolveTests.swift in Sources */,
 				1112390E6B51D137AD0266BE /* ResolverParentTests.swift in Sources */,
+				8DDE60FF2457391E00654EF3 /* InjectAnnotationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -418,6 +423,7 @@
 				3293A63C5BFF5635329AB678 /* Hash.swift in Sources */,
 				F88E34808EB209752657ED2E /* Injection.swift in Sources */,
 				FEC4D83F4E69CDA953236C92 /* LogLevel.swift in Sources */,
+				8DDE60FD2457327700654EF3 /* Inject.swift in Sources */,
 				93E103D383C3CBDED1495792 /* Logger.swift in Sources */,
 				678FC8AFB8F69F7C61D3FAA2 /* Module.swift in Sources */,
 				19F4E330AD406A40612894FD /* ModuleBuilder.swift in Sources */,

--- a/Injection/Sources/Component.swift
+++ b/Injection/Sources/Component.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+/// Group a bunch of factories.
+/// This Compoentn could be used to provide factories to another `Component` or to create a `Module`
+///
+/// **Example**
+///
+/// let yourComponent = Component {
+///     factory { Service() }
+///     single { OneSingleton() }
+/// }
+///
 public struct Component {
     let _entries: [Entry]
 }

--- a/Injection/Sources/Inject.swift
+++ b/Injection/Sources/Inject.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Struct property wrapper to autowire instances by type.
+/// - `T` is the type of the instance you want to intject
+///
+/// - note: This instances will be resolved by the `injectMe` module.
+///
+/// let service: @Inject<Service>
+///
+@propertyWrapper
+public struct Inject<T> {
+
+    public private(set) var wrappedValue: T
+
+    private let tag: String?
+
+    public init() {
+        self.tag = nil
+        self.wrappedValue = resolve(tag: tag)
+    }
+
+    /// Resolve the T instance using the given tag
+    /// - parameter tag: String used to locate your instance
+    public init(tag: String) {
+        self.tag = tag
+        self.wrappedValue = resolve(tag: tag)
+    }
+
+}
+
+/// Struct property wrapper to lazy autowire instances by type.
+/// - `T` is the type of the instance you want to intject
+///
+/// - note: This instances will be resolved by the `injectMe` module.
+///
+/// let service: @LazyInject<Service>
+///
+@propertyWrapper
+public struct LazyInject<T> {
+
+    private var _value: T?
+    public var wrappedValue: T {
+        mutating get { value() }
+    }
+
+    private let tag: String?
+
+    public init() {
+        self.tag = nil
+    }
+
+    /// Resolve the T instance using the given tag
+    /// - parameter tag: String used to locate your instance
+    public init(tag: String?) {
+        self.tag = tag
+    }
+
+    private mutating func value() -> T {
+        if _value == nil { _value = resolve(tag: tag) }
+        return _value!
+    }
+
+}

--- a/Injection/Sources/Injection.swift
+++ b/Injection/Sources/Injection.swift
@@ -41,8 +41,8 @@ final class Injection {
     private func notInitialized() -> Module {
         fatalError("Injection not initialized. Must call initInjection before")
     }
-    
-    //only test purpose.
+
+    // only test purpose.
     static func reset() {
         shared._module = nil
     }

--- a/Injection/Tests/InjectAnnotationTests.swift
+++ b/Injection/Tests/InjectAnnotationTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+@testable import Injection
+import Nimble
+import XCTest
+
+final class InjectPropertyWrapperTests: XCTestCase {
+
+    let module = Module {
+        factory { Service(name: "A") }
+        factory(tag: "B") { Service(name: "B") }
+        factory { Injected() }
+        factory { Lazy() }
+        factory { InjectedB() }
+        factory { LazyB() }
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        Injection.reset()
+    }
+
+    func testInjectPropertyWrapper() {
+        Injection.initialize(with: module)
+
+        expect { _ = resolve() as Injected }.toNot(throwAssertion())
+    }
+
+    func testLazyInjectPropertyWrapper() {
+        Injection.initialize(with: module)
+
+        expect { _ = resolve() as Lazy }.toNot(throwAssertion())
+    }
+
+    func testInjectPropertyWrapperWithTag() {
+        Injection.initialize(with: module)
+
+        let injected = resolve() as InjectedB
+
+        expect(injected.service.name).to(equal("B"))
+    }
+
+    func testLazyInjectPropertyWrapperWithTag() {
+        Injection.initialize(with: module)
+
+        let injected = resolve() as LazyB
+
+        expect(injected.service.name).to(equal("B"))
+    }
+
+}
+
+private struct Service {
+    let name: String
+
+    init(name: String) {
+        self.name = name
+    }
+}
+
+private class Injected {
+    @Inject var service: Service
+}
+
+private class Lazy {
+    @LazyInject var service: Service
+}
+
+private class InjectedB {
+    @Inject(tag: "B") var service: Service
+}
+
+private class LazyB {
+    @LazyInject(tag: "B") var service: Service
+}

--- a/Readme.md
+++ b/Readme.md
@@ -308,6 +308,22 @@ of the module and I can override without problems.
 **So, keep in mind, TRY TO AVOID OVERRIDE SINGLETON DEPENDENCIES, BECAUSE THE SINGLETON CAN BE ALREADY CREATED WHEN YOU THINK YOU'RE CREATING IT**
 
 
+### Property Wrappers
+
+You can use property wrappers to resolve instances provided previously to the shared module by `injectMe`.
+
+`@Inject` will be instanciated on initialization
+`@LazyInect` will be instanced by demand
+
+```swift
+@Inject service: Service
+@LazyInject service: Service
+
+//With tags
+@Inject(tag: "tag") service: Service
+@LazyInject(tag: "tag") service: Service
+```
+
 ### Logger
 
 There is a Logger that will print all the operations while reoslving a type.

--- a/Readme.md
+++ b/Readme.md
@@ -374,3 +374,7 @@ This option is not available yet ☹️. But I appreciate it.
 #### More info
 
 DSL functions inspired on [Koin](https://insert-koin.io/)
+
+## Author
+
+Developed by: Julian Alonso, find me on Twitter - [@maisterjuli](https://twitter.com/MaisterJuli)


### PR DESCRIPTION
Closes #9 

Supporting Property Wrappers
Both resolves properties previously provided on the shared module by `injectMe`
`@Inject` - Resolves the property on creation
`@LazyInject` - Resolves the property by demand